### PR TITLE
Extract common functionality shell settings

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,7 +1,7 @@
 # ~/.bashrc
 # vim:set ft=sh sw=2 sts=2:
 
-source "$HOME/.hashrc"
+source "$HOME/.shellrc"
 
 # Store 10,000 history entries
 export HISTSIZE=10000

--- a/.hashrc
+++ b/.hashrc
@@ -4,22 +4,6 @@
 [ -e "$HASHROCKET_DIR" ] || HASHROCKET_DIR="$HOME/hashrocket"
 export HASHROCKET_DIR
 
-for dir in /usr/local/bin "$HOME/bin" .git/safe/../../bin .git/bin; do
-  case "$PATH:" in
-    *:"$dir":*) PATH="`echo "$PATH"|sed -e "s#:$dir##"`" ;;
-  esac
-  case "$dir" in
-    /*) [ ! -d "$dir" ] || PATH="$dir:$PATH" ;;
-    *) PATH="$dir:$PATH" ;;
-  esac
-done
-for dir in /usr/local/sbin /opt/local/sbin /usr/X11/bin; do
-  case ":$PATH:" in
-    *:"$dir":*) ;;
-    *) [ ! -d "$dir" ] || PATH="$PATH:$dir" ;;
-  esac
-done
-
 hcd() {
   cd "$HASHROCKET_DIR/$1"
   if [ -e .git/safe -a ! -L .git/bin ]; then
@@ -197,9 +181,6 @@ alias testify="watchr ~/.watchr.rb"
 alias vanguard="guard -c -n false"
 alias vangaurd="vanguard"
 
-alias ll='ls -l'
-
-
 setup_tmux_pasteboard () {
  git clone https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard.git
  cd tmux-MacOSX-pasteboard
@@ -229,59 +210,6 @@ contributions () {
   { for(i=1; i<=NF; i++) { count[$i]++; } }'
 
   git log --format="%an" $@ | awk $prog | sort -nr | column -t -s '|'
-}
-
-# git_prompt_info accepts 0 or 1 arguments (i.e., format string)
-# returns text to add to bash PS1 prompt (includes branch name)
-git_prompt_info () {
-  local g="$(git rev-parse --git-dir 2>/dev/null)"
-  if [ -n "$g" ]; then
-    local r
-    local b
-    local d
-    local s
-    # Rebasing
-    if [ -d "$g/rebase-apply" ] ; then
-      if test -f "$g/rebase-apply/rebasing" ; then
-        r="|REBASE"
-      fi
-      b="$(git symbolic-ref HEAD 2>/dev/null)"
-    # Interactive rebase
-    elif [ -f "$g/rebase-merge/interactive" ] ; then
-      r="|REBASE-i"
-      b="$(cat "$g/rebase-merge/head-name")"
-    # Merging
-    elif [ -f "$g/MERGE_HEAD" ] ; then
-      r="|MERGING"
-      b="$(git symbolic-ref HEAD 2>/dev/null)"
-    else
-      if [ -f "$g/BISECT_LOG" ] ; then
-        r="|BISECTING"
-      fi
-      if ! b="$(git symbolic-ref HEAD 2>/dev/null)" ; then
-        if ! b="$(git describe --exact-match HEAD 2>/dev/null)" ; then
-          b="$(cut -c1-7 "$g/HEAD")..."
-        fi
-      fi
-    fi
-
-    # Dirty Branch
-    local newfile='?? '
-    if [ -n "$ZSH_VERSION" ]; then
-      newfile='\?\? '
-    fi
-    d=''
-    s=$(git status --porcelain 2> /dev/null)
-    [[ $s =~ "$newfile" ]] && d+='+'
-    [[ $s =~ "M " ]] && d+='*'
-    [[ $s =~ "D " ]] && d+='-'
-
-    if [ -n "${1-}" ]; then
-      printf "$1" "${b##refs/heads/}$r$d"
-    else
-      printf "(%s) " "${b##refs/heads/}$r$d"
-    fi
-  fi
 }
 
 gco () {

--- a/.shellrc
+++ b/.shellrc
@@ -1,0 +1,75 @@
+# This is sourced in bashrc and zshrc
+
+for dir in /usr/local/bin "$HOME/bin" .git/safe/../../bin .git/bin; do
+  case "$PATH:" in
+    *:"$dir":*) PATH="`echo "$PATH"|sed -e "s#:$dir##"`" ;;
+  esac
+  case "$dir" in
+    /*) [ ! -d "$dir" ] || PATH="$dir:$PATH" ;;
+    *) PATH="$dir:$PATH" ;;
+  esac
+done
+
+for dir in /usr/local/sbin /opt/local/sbin /usr/X11/bin; do
+  case ":$PATH:" in
+    *:"$dir":*) ;;
+    *) [ ! -d "$dir" ] || PATH="$PATH:$dir" ;;
+  esac
+done
+
+alias ll='ls -l'
+
+# git_prompt_info accepts 0 or 1 arguments (i.e., format string)
+# returns text to add to bash PS1 prompt (includes branch name)
+git_prompt_info () {
+  local g="$(git rev-parse --git-dir 2>/dev/null)"
+  if [ -n "$g" ]; then
+    local r
+    local b
+    local d
+    local s
+    # Rebasing
+    if [ -d "$g/rebase-apply" ] ; then
+      if test -f "$g/rebase-apply/rebasing" ; then
+        r="|REBASE"
+      fi
+      b="$(git symbolic-ref HEAD 2>/dev/null)"
+    # Interactive rebase
+    elif [ -f "$g/rebase-merge/interactive" ] ; then
+      r="|REBASE-i"
+      b="$(cat "$g/rebase-merge/head-name")"
+    # Merging
+    elif [ -f "$g/MERGE_HEAD" ] ; then
+      r="|MERGING"
+      b="$(git symbolic-ref HEAD 2>/dev/null)"
+    else
+      if [ -f "$g/BISECT_LOG" ] ; then
+        r="|BISECTING"
+      fi
+      if ! b="$(git symbolic-ref HEAD 2>/dev/null)" ; then
+        if ! b="$(git describe --exact-match HEAD 2>/dev/null)" ; then
+          b="$(cut -c1-7 "$g/HEAD")..."
+        fi
+      fi
+    fi
+
+    # Dirty Branch
+    local newfile='?? '
+    if [ -n "$ZSH_VERSION" ]; then
+      newfile='\?\? '
+    fi
+    d=''
+    s=$(git status --porcelain 2> /dev/null)
+    [[ $s =~ "$newfile" ]] && d+='+'
+    [[ $s =~ "M " ]] && d+='*'
+    [[ $s =~ "D " ]] && d+='-'
+
+    if [ -n "${1-}" ]; then
+      printf "$1" "${b##refs/heads/}$r$d"
+    else
+      printf "(%s) " "${b##refs/heads/}$r$d"
+    fi
+  fi
+}
+
+[ -f "$HOME/.hashrc" ] && source "$HOME/.hashrc"

--- a/.zshrc
+++ b/.zshrc
@@ -4,7 +4,7 @@ fpath=(
   ~/.zsh/functions
 )
 
-source "$HOME/.hashrc"
+source "$HOME/.shellrc"
 
 # color term
 export CLICOLOR=1


### PR DESCRIPTION
We will be moving .hashrc to another repository to make dotmatrix easier
for non-Hashrocket folks to install and use.

This will play nicely with our new bin/install script, which excludes .hashrc

Any thoughts on making this better, @tpope ?
