### PR TITLE
Add rmbranch alias to gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -17,6 +17,7 @@
 	add-untracked = !"git status --porcelain | awk '/\\?\\?/{ print $2 }' | xargs git add"
 	ln = log --pretty=format:'%Cblue%h %Cred* %C(yellow)%s'
 	reset-authors = commit --amend --reset-author -CHEAD
+        rmbranch = "!f(){ git branch -d ${1} && git push origin --delete ${1};f"
 [branch]
 	autosetuprebase = always
 [color]


### PR DESCRIPTION
The new alias runs `git branch -d <branchname>` and then runs `git
push origin --delete`.  Removes the branch local and remotely if changes
have been merged upstream.

Passes `-p` flag which (from git-branch man):

> Delete a branch. The branch must be fully merged in its upstream branch,
> or in HEAD if no upstream was set with --track or
>           --set-upstream.

More information can be found [here](http://stackoverflow.com/questions/2003505/how-do-i-delete-a-git-branch-both-locally-and-in-github)
