### PR TITLE
Add snapshot git alias

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -18,6 +18,7 @@
 	ln = log --pretty=format:'%Cblue%h %Cred* %C(yellow)%s'
 	reset-authors = commit --amend --reset-author -CHEAD
 	rmbranch = "!f(){ git branch -d ${1} && git push origin --delete ${1}; };f"
+        snapshot = !git stash save "snapshot: $(date)" && git stash apply "stash@{0}"
 [branch]
 	autosetuprebase = always
 [color]


### PR DESCRIPTION
Alias for creating a copy of your current working directory (dirty or not) and adding it to the stash then applying it again.
- stash - creates a message with the time of snapshot, and stashes
- apply - returns you back to where you were at

Use case would be to create a quick snapshot then do some **exploratory** coding.  When you are done you can revert back to the snapshot in the stash list, or you can go with the changes.

Credit: [here](http://blog.apiaxle.com/post/handy-git-tips-to-stop-you-getting-fired/)
