### PR TITLE
Abstract Trim to plugin

### DIFF
--- a/.vim/plugin/hashrocket.vim
+++ b/.vim/plugin/hashrocket.vim
@@ -28,7 +28,6 @@ Hcommand split
 Hcommand saveas
 Hcommand tabedit
 
-command! -bar -range=% Trim :<line1>,<line2>s/\s\+$//e
 command! -bar -range=% NotRocket :<line1>,<line2>s/:\(\w\+\)\s*=>/\1:/ge
 
 function! HTry(function, ...)

--- a/bin/vimbundles.sh
+++ b/bin/vimbundles.sh
@@ -56,5 +56,6 @@ get_bundle jgdavey tslime.vim
 get_bundle jgdavey vim-turbux
 get_bundle jgdavey vim-weefactor
 get_bundle gregsexton gitv
+get_bundle rondale-sc vim-spacejam
 
 vim -c 'call pathogen#helptags()|q'


### PR DESCRIPTION
Wrote a plugin that replaces the existing :Trim command.  Upon trimming trailing whitespace it ensures that your cursor is returned to where it was before the command was run.  

This is automatically run before save for files with extensions, .rb, .js, and .py.

Review the plugin here: [Vim SpaceJam](https://github.com/rondale-sc/vim-spacejam)
