### PR TITLE
Add list and verbose options to the vimbundle installer

### DIFF
--- a/bin/vimbundles.sh
+++ b/bin/vimbundles.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 
+# use call with -l to list github address of all bundles
+# use with -l -v to see the head of all readmes
+
+LIST_ONLY=false
+VERBOSE=false
+
+OPTIND=1
+while getopts "lv" opt; do
+  case "$opt" in
+    l)
+      LIST_ONLY=true
+      ;;
+    v)
+      VERBOSE=true
+      ;;
+  esac
+done
+
 if [ ! -d "$HOME/.vimbundles" ]; then
   BASE="$HOME/.vim/bundle"
 else
@@ -14,13 +32,22 @@ install_from() {
     for repo in $repos; do
       cd $BASE
       dir="$(basename $repo)"
-      echo
-      if [ -d "$BASE/$dir" ]; then
-        echo "Updating $repo"
-        cd "$BASE/$dir"
-        git pull --rebase
+      if $LIST_ONLY; then
+        echo "https://github.com/$repo"
+        if $VERBOSE; then
+          find "$dir" -maxdepth 1 -iname "README*" | xargs head
+          echo "============================================================="
+          echo "============================================================="
+        fi
       else
-        git clone https://github.com/"$repo".git
+        echo
+        if [ -d "$BASE/$dir" ]; then
+          echo "Updating $repo"
+          cd "$BASE/$dir"
+          git pull --rebase
+        else
+          git clone https://github.com/"$repo".git
+        fi
       fi
     done
   fi


### PR DESCRIPTION
Run the following to get a list of hyperlinks (clickable if your
terminal is good): `bin/vimbundles.sh -l`

Run the following to get first few lines of each readme, pipe to less
as it's a bit long: `bin/vimbundles.sh -l -v | less`

Thought you might like this, I find this useful.