### PR TITLE
Create tags for nested CoffeeScript constants

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -15,6 +15,7 @@
 --regex-CoffeeScript=/(^|=[ \t])*class ([A-Za-z.]+)( extends [A-Za-z.]+)?$/\2/c,class/
 --regex-CoffeeScript=/^[ \t]*@?([A-Za-z.]+):.*[-=]>.*$/\1/f,function/
 --regex-CoffeeScript=/^[ \t]*([A-Za-z.]+)[ \t]+=.*[-=]>.*$/\1/f,function/
+--regex-CoffeeScript=/(^|\.)([A-Z][[:alnum:]_]+) *=/\2/c,class,constant/
 
 --langdef=Go
 --langmap=Go:.go


### PR DESCRIPTION
This lets ctags create tags for nested CoffeeScript constants like:

    Seq25.Note