### PR TITLE
.gitconfig.local should be the last thing in .gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -30,8 +30,6 @@
 	whitespace = warn
 [help]
 	autocorrect = 10
-[include]
-	path = ~/.gitconfig.local
 [interactive]
 	singlekey = true
 [merge]
@@ -58,3 +56,5 @@
 	autosquash = true
 [diff]
 	algorithm = patience
+[include]
+	path = ~/.gitconfig.local


### PR DESCRIPTION
Per the git documentation:

> The included file is expanded immediately, as if its contents had been
> found at the location of the include directive.

Which is to say that any settings in `.gitconfig` that appear _after_
the `include.path` setting will override settings in the included file.
Since `.gitconfig.local` settings should always override the defaults in
`.gitconfig`, the `core.include` directive should come last.
