### PR TITLE
Separates ignored dirs into different flags.

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -5,4 +5,6 @@
 --type-set=sass=.sass,.scss
 
 # Do not search these directories for quicker lookup
---ignore-dir=log,tags,tmp
+--ignore-dir=log
+--ignore-dir=tags
+--ignore-dir=tmp


### PR DESCRIPTION
Using the syntax before ack was looking inside the log folder and taking a whole lot of time.