### PR TITLE
Clone a shallow copy of vim plugins

### DIFF
--- a/bin/vimbundles.sh
+++ b/bin/vimbundles.sh
@@ -33,10 +33,10 @@ action_from() {
           git log --since $date --color=always >>/tmp/vimbundles.log
         else
           echo "Updating $repo"
-          git pull --rebase
+          git pull --depth=1 --rebase
         fi
       else
-        git clone https://github.com/"$repo".git
+        git clone --depth=1 https://github.com/"$repo".git
       fi
     done
   fi


### PR DESCRIPTION
Setting the `--depth=1` option on clone makes cloning faster and take less disk space since it uses a shallow clone. 
This means only a shallow copy of the codebase at the latest commit is actually being pulled rather than the whole git history tree with every revision ever made.

The same applies for updating plugins, we now call `git pull` with `--depth=1`.