### PR TITLE
Reset empty files after `gnap`

### DIFF
--- a/.sharedrc
+++ b/.sharedrc
@@ -126,8 +126,13 @@ gcr() {
   git checkout -b $1 origin/$1
 }
 
+# git reset empty files
+gref() {
+  command git --no-pager diff --cached --stat | command grep "|\s*0$" | awk '{system("command git reset " $1)}'
+}
+
 alias gap='git add -p'
-alias gnap='git add -N . && git add -p'
+alias gnap='git add -N . && gap && gref'
 alias glp='git log -p'
 alias glg='git log --graph --oneline --decorate --color --all'
 alias gb='git branch'


### PR DESCRIPTION
- [x] reset empty files after `gnap`
- [x] tested locally with:
  - [x] bash
    - [x] git 2.6.4
    - [x] `hub` 2.2.3 proxying git 2.6.4
  - [x] zsh
    - [x] git 2.6.4
    - [x] `hub` 2.2.3 proxying git 2.6.4

<img width="695" alt="screen shot 2016-04-25 at 9 15 30 pm" src="https://cloud.githubusercontent.com/assets/1071893/14803805/ffe2a2e4-0b2a-11e6-8e16-80b5df93f03e.png">
