### PR TITLE
Move OS X-specific config to separate file

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -35,12 +35,7 @@ bind -t vi-copy y copy-pipe 'reattach-to-user-namespace pbcopy'
 bind -t vi-copy v begin-selection
 bind -t vi-copy V rectangle-toggle
 
-# Mouse options for tmux >= 2.1
-set-option -g -q mouse on
-bind-key -T root WheelUpPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; copy-mode -e; send-keys -M"
-bind-key -T root WheelDownPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; send-keys -M"
-bind-key -t vi-copy WheelUpPane halfpage-up
-bind-key -t vi-copy WheelDownPane halfpage-down
+if-shell 'uname | grep -q Darwin' 'source-file ~/.tmux.osx.conf'
 
 # Better project name in status bar
 set -g status-left-length 18

--- a/.tmux.osx.conf
+++ b/.tmux.osx.conf
@@ -1,0 +1,6 @@
+# Mouse options for tmux >= 2.1
+set-option -g -q mouse on
+bind-key -T root WheelUpPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; copy-mode -e; send-keys -M"
+bind-key -T root WheelDownPane if-shell -F -t = "#{alternate_on}" "send-keys -M" "select-pane -t =; send-keys -M"
+bind-key -t vi-copy WheelUpPane halfpage-up
+bind-key -t vi-copy WheelDownPane halfpage-down


### PR DESCRIPTION
This commit fixes my problem on my Digital Ocean server, but (unless I'm mistaken) would clobber mouse support for all non-OS X users. :\

I guess what I'm looking for is a way to test for mouse support so that this tmux config doesn't throw errors on my server - thoughts?