### PR TITLE
Prompt for deleted files on `gnap`

### DIFF
--- a/.sharedrc
+++ b/.sharedrc
@@ -132,7 +132,7 @@ gref() {
 }
 
 alias gap='git add -p'
-alias gnap='git add -N . && gap && gref'
+alias gnap='git add -N --ignore-removal . && gap && gref'
 alias glp='git log -p'
 alias glg='git log --graph --oneline --decorate --color --all'
 alias gb='git branch'


### PR DESCRIPTION
Deleted files were being added to git stage by `git add -N` so the user was not being prompted.

- [x] add `--ignore-removal` to `git add -N`

## test:
<img width="251" alt="screen shot 2016-05-08 at 11 49 36 am" src="https://cloud.githubusercontent.com/assets/1071893/15098791/62c5bea4-1513-11e6-9a1e-485f16250403.png">

## result:
<img width="467" alt="screen shot 2016-05-08 at 11 52 14 am" src="https://cloud.githubusercontent.com/assets/1071893/15098792/62cfbdb4-1513-11e6-8f75-05fdbcc9b0f1.png">
