### PR TITLE
Save history for IRB and Rails console

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -33,4 +33,7 @@ def clippy
   @clippy
 end
 
+IRB.conf[:SAVE_HISTORY] = 200
+IRB.conf[:HISTORY_FILE] = '~/.irb-history'
+
 load File.expand_path("~/.irbrc.local") if File.exists?(File.expand_path("~/.irbrc.local"))


### PR DESCRIPTION
If you close your `rails console` or `irb` the history will be persisted.

So next time you open it just use the arrows UP/DOWN to get your history back.