### PR TITLE
Remove IRB dependency from Pry

### DIFF
--- a/.clippy.rb
+++ b/.clippy.rb
@@ -1,0 +1,34 @@
+class Clippy
+  def paste
+    IO.read("|pbpaste").chomp
+  end
+
+  def copy(string)
+    IO.popen("pbcopy", "w") do |p|
+      p.puts(string)
+    end
+    string
+  end
+
+  def <<(string)
+    copy(paste + string)
+  end
+
+  def clear
+    copy("")
+  end
+
+  def to_s
+    paste
+  end
+
+  def inspect
+    to_s
+  end
+end
+
+def clippy
+  @clippy ||= Clippy.new
+  @clippy.copy yield if block_given?
+  @clippy
+end

--- a/.irbrc
+++ b/.irbrc
@@ -1,39 +1,5 @@
-class Clippy
-  def paste
-    IO.read("|pbpaste").chomp
-  end
-
-  def copy(string)
-    IO.popen("pbcopy", "w") do |p|
-      p.puts(string)
-    end
-    string
-  end
-
-  def <<(string)
-    copy(paste + string)
-  end
-
-  def clear
-    copy("")
-  end
-
-  def to_s
-    paste
-  end
-
-  def inspect
-    to_s
-  end
-end
-
-def clippy
-  @clippy ||= Clippy.new
-  @clippy.copy yield if block_given?
-  @clippy
-end
-
 IRB.conf[:SAVE_HISTORY] = 200
 IRB.conf[:HISTORY_FILE] = '~/.irb-history'
 
+load File.expand_path("~/.clippy.rb") if File.exists?(File.expand_path("~/.clippy.rb"))
 load File.expand_path("~/.irbrc.local") if File.exists?(File.expand_path("~/.irbrc.local"))

--- a/.pryrc
+++ b/.pryrc
@@ -1,4 +1,2 @@
-["~/.irbrc", "~/.pryrc.local"].each do |file|
-  path = File.expand_path file
-  load path if File.exists?(path)
-end
+load File.expand_path("~/.clippy.rb") if File.exists?(File.expand_path("~/.clippy.rb"))
+load File.expand_path("~/.pryrc.local") if File.exists?(File.expand_path("~/.pryrc.local"))


### PR DESCRIPTION
IRB is not required by default:

```sh
micah@local:~% ruby -e IRB
-e:1:in `<main>': uninitialized constant IRB (NameError)
```

I have some scripts that start a Pry console via `Pry.start`. Because the `.pryrc` requires the `.irbrc` and that uses the `IRB` constant I get errors.

The only shared behavior that I can see is the clippy code. I extracted this code into another dotfile and required it from each `.pryrc` and `.irbrc`. This fixes the problem. Not sure if this is the best place for the clippy code to live, or if it should be extracted into a gem and required conditionally?