### PR TITLE
Remove vimbundles deprecation

### DIFF
--- a/bin/vimbundles.sh
+++ b/bin/vimbundles.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-warn() {
-  echo "WARNING: $1" >&2
-}
-
-
-warn "$0 is deprecated and will be removed."
-warn "Please use hr's vimbundle command (it's faster and better)."
-warn "More info at http://github.com/hashrocket/hr"
-echo
-
 if [ ! -d "$HOME/.vimbundles" ]; then
   BASE="$HOME/.vim/bundle"
 else


### PR DESCRIPTION
Many people have never installed `hr`. Even many people in the Jax office.

This deprecation means that dotmatrix now has a hard dependency on `hr`. I don't think this is a good idea. I am all for a faster script, and that script can even be ruby. But all installation and updating (which is specific to dotmatrix) needs to live in this repo.

If we do chose to make a hard dependency on `hr` then it should be documented in this projects README. These are breaking changes.