### PR TITLE
Require flag for workstation install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ $ bin/install
 
 This script symlinks all dotfiles into your home directory.
 
+### Hashrocket Workstation
+
+Dotmatrix comes with gitconfig for our Hashrocket Workstations that can be
+installed like so:
+
+```
+$ bin/install --workstation
+```
+
 ## Safe by Default
 
 When you install Dotmatrix like this, only files that do not already exist in

--- a/bin/dot_functions.sh
+++ b/bin/dot_functions.sh
@@ -16,7 +16,6 @@ create_notice() {
   print_padded "Creating $1" "$2" $green
 }
 
-
 skip_notice() {
   print_padded "${yellow}Skipping${normal} $1" "$2" $yellow
 }

--- a/bin/install
+++ b/bin/install
@@ -15,17 +15,19 @@ else
 fi
 
 # Copy *.local files
-for dotfile in .*.local ; do
-  dotmatrix_path=$PWD/$dotfile
-  path="$HOME/$dotfile"
+if [ "$1" = "--workstation" ]; then
+  for dotfile in .*.local ; do
+    dotmatrix_path=$PWD/$dotfile
+    path="$HOME/$dotfile"
 
-  if [ ! -e $path ]; then
-    copy_notice $dotfile "absent"
-    cp $dotmatrix_path $path
-  else
-    skip_notice $dotfile "exists"
-  fi
-done
+    if [ ! -e $path ]; then
+      copy_notice $dotfile "absent"
+      cp $dotmatrix_path $path
+    else
+      skip_notice $dotfile "exists"
+    fi
+  done
+fi
 
 for dotfile in $(./bin/file_list.sh); do
   dotmatrix_path="$PWD/$dotfile"

--- a/bin/install
+++ b/bin/install
@@ -59,4 +59,10 @@ if [[ "$OSTYPE" == 'darwin'* ]]; then
   done
 fi
 
+if [ -e "$HOME/.gitconfig.local" ]; then
+  echo -e "\nNo .gitconfig.local found - if you want the workstation version run this:"
+  echo -e "  $ cp .gitconfig.local ~/"
+  echo -e "Reminder: pass the --workstation flag to copy this file automatically.\n"
+fi
+
 $PWD/hr/bin/hr autoinstall

--- a/bin/install
+++ b/bin/install
@@ -59,7 +59,7 @@ if [[ "$OSTYPE" == 'darwin'* ]]; then
   done
 fi
 
-if [ -e "$HOME/.gitconfig.local" ]; then
+if [ ! -e "$HOME/.gitconfig.local" ]; then
   echo -e "\nNo .gitconfig.local found - if you want the workstation version run this:"
   echo -e "  $ cp .gitconfig.local ~/"
   echo -e "Reminder: pass the --workstation flag to copy this file automatically.\n"


### PR DESCRIPTION
All I've done here is wrap the loop that copies the `.gitconfig.local` file in a conditional that looks for a `--workstation` flag.

My reasoning is that Dotmatrix is a open-source project we encourage people to use and yet the default installation tries to make the machine a Hashrocket Workstation. I don't think that's very friendly and we've been working on reducing the Hashrocket-specific things - this seems like a prime candidate.

This change does mean that when you *are* setting up a Hashrocket Workstation you have to remember to pass that flag, but I think that's worth it. Even if you forget, it's really just as simple as:

```
$ cp .gitconfig.local ~/
```

One more thing: that loop is probably overkill for the one `.local` file that we've got. It's nice that if we had another `.local` file then it would be picked up too, but maybe what we've got here is some premature optimization?

Might be nice if that looked more like this:

```
# Copy .gitconfig.local files
if [ "$1" = "--workstation" ]; then
  dotfile=".gitconfig.local"
  dotmatrix_path=$PWD/$dotfile
  path="$HOME/$dotfile"

  if [ ! -e $path ]; then
    copy_notice $dotfile "absent"
    cp $dotmatrix_path $path
  else
    skip_notice $dotfile "exists"
  fi
fi
```

If people are into that I can do another PR. ❤️  ❤️  ❤️ 