### PR TITLE
Add `cheddar` as an alias

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -3,6 +3,7 @@
 	aa = add -A .
 	b  = branch
 	st = status
+	cheddar = commit --amend -CHEAD
 	ci = commit
 	co = checkout
 	cp = cherry-pick


### PR DESCRIPTION
This is a handy alias we've ported across several machines in the Hashrocket office. Now we all can use it.