### PR TITLE
Enable the built-in man page plugin

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -3,6 +3,7 @@ if $VIM_PLUGINS != 'NO'
   if exists('g:loaded_pathogen')
     execute pathogen#infect('~/.vimbundles/{}', '~/.vim/bundle/{}')
   endif
+  runtime! ftplugin/man.vim
 endif
 
 syntax on


### PR DESCRIPTION
This makes it easy to pull up man pages within Vim using, for example,
`:Man grep`.