### PR TITLE
Add hr battery command

### DIFF
--- a/hr/libexec/hr-battery
+++ b/hr/libexec/hr-battery
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+#
+# Usage: hr battery [options]
+#
+# Summary: Show battery percentage, with various formatting options
+#
+# Help: By default, prints just the battery percentage.
+#
+# Options:
+#   --charging     Print even when plugged in (default prints nothing when plugged in)
+#   --color        Print with color (depending on formatter)
+#   --tmux         Print with tmux formatting (for status bar)
+#   --format=[opt] One of percent, bar, icon, block, or hearts,
+#                  or a format string (any of the opts, prefixed with %)
+#
+# This utility is known to work with OS X and Ubuntu, but may work with other Linux distros.
+
+if [ "$1" = "--complete" ]; then
+    echo --charging
+    echo --color
+    echo --tmux
+    echo --format=percent
+    echo --format=hearts
+    exit
+fi
+
+# Default options
+format=percent
+color=
+charging=
+tmux=
+
+# Parse options
+while [ $# -gt 0 ]; do
+  case "$1" in
+      --charging) charging=1 ;;
+      -c|--color) color=1 ;;
+      -t|--tmux)  tmux=1 ;;
+      -f|--format*)
+          if echo "$1" | grep -q "=[^ ]"; then
+              format=$(echo "$1" | sed -e 's/^[^=]*=//g')
+          else
+              format="$2"
+              shift
+          fi
+          ;;
+      (--) shift; break ;;
+      (*) break ;;
+  esac
+  shift
+done
+
+# Grab battery status
+BATTERY_DISCHARGING=
+BATTERY_PERCENTAGE=
+case $(uname -s) in
+    "Linux")
+        batpath="/sys/class/power_supply/BAT0"
+        status="$(cat $batpath/status)"
+        if [ "$status" = "Discharging" ]; then
+            BATTERY_DISCHARGING=1
+        fi
+        bf=$(cat $batpath/energy_full)
+        bn=$(cat $batpath/energy_now)
+        BATTERY_PERCENTAGE="$(( 100 * $bn / $bf ))"
+        ;;
+    "Darwin")
+        info="$(pmset -g batt)"
+        status=$(echo "$info" | grep -io '\(battery\|ac\) power')
+        if [ "$status" = "Battery Power" ]; then
+            BATTERY_DISCHARGING=1
+        fi
+        BATTERY_PERCENTAGE=$(echo "$info" | grep -o "\d\+%" | sed 's/%//')
+        ;;
+    *)
+        # Unsupported platform
+        exit 1
+        ;;
+esac
+
+# Bail if it didn't work
+if [ -z "$BATTERY_PERCENTAGE" ]; then
+    exit 1
+fi
+
+# Bail if charging and the --charging flag isn't set
+if [ -z "$BATTERY_DISCHARGING" -a ! -n "$charging" ]; then
+    exit
+fi
+
+
+# Setup colors
+[ -e "$NUM_HEARTS" ] || NUM_HEARTS=5
+
+if [ -n "$color" ]; then
+    if [ -n "$tmux" ]; then
+        RESET_COLOR="#[default]"
+        GREEN_BG='#[bg=green]'
+        GREEN_FG='#[fg=green]'
+        RED_BG='#[bg=red]'
+        RED_FG='#[fg=red]'
+        YELLOW_BG='#[bg=yellow]'
+        YELLOW_FG='#[fg=yellow]'
+        ORANGE_BG='#[bg=colour208]'
+        ORANGE_FG='#[fg=colour208]'
+    else
+        RESET_COLOR="\033[0;0m"
+        GREEN_BG="\033[0;42m"
+        GREEN_FG="\033[0;32m"
+        RED_BG="\033[0;41m"
+        RED_FG="\033[0;31m"
+        YELLOW_BG="\033[0;43m"
+        YELLOW_FG="\033[0;33m"
+        ORANGE_BG="\033[1;43m"
+        ORANGE_FG="\033[1;33m"
+    fi
+fi
+
+bg_color() {
+    percent="$BATTERY_PERCENTAGE"
+    if   (( $percent > 80 )); then c=$GREEN_BG
+    elif (( $percent > 50 )); then c=$YELLOW_BG
+    elif (( $percent > 30 )); then c=$ORANGE_BG
+    else                           c=$RED_BG
+    fi
+    echo -e "$c"
+}
+
+fg_color() {
+    percent="$BATTERY_PERCENTAGE"
+    if   (( $percent > 80 )); then c=$GREEN_FG
+    elif (( $percent > 50 )); then c=$YELLOW_FG
+    elif (( $percent > 30 )); then c=$ORANGE_FG
+    else                           c=$RED_FG
+    fi
+    echo -e "$c"
+}
+
+colorize_bg() {
+    c="$(bg_color)"
+    echo -e "$c$1$RESET_COLOR"
+}
+
+colorize_fg() {
+    c="$(fg_color)"
+    echo -e "$c$1$RESET_COLOR"
+}
+
+# Formatters
+
+format_hearts() {
+    heart_full="♥"
+    heart_empty="♡"
+    perc=$BATTERY_PERCENTAGE
+    inc=$(( 100 / $NUM_HEARTS))
+    hearts=""
+    for i in `seq $NUM_HEARTS`; do
+        if [ $perc -gt 0 ]; then
+            hearts="$hearts $heart_full"
+        else
+            hearts="$hearts $heart_empty"
+        fi
+        perc=$(( $perc - $inc ))
+    done
+    echo -e "$RED_FG${hearts## }$RESET_COLOR"
+}
+
+format_percent() {
+    if [ -n "$tmux" ]; then
+        colorize_bg "$BATTERY_PERCENTAGE%"
+    else
+        colorize_fg "$BATTERY_PERCENTAGE%"
+    fi
+}
+
+format_bar() {
+    ascii_bar='=========='
+    barlength=${#ascii_bar}
+
+    n=$(echo "scale = 1; $barlength * ($BATTERY_PERCENTAGE / 100) + 0.5" | bc)
+    rounded_n=$(printf "%.0f" "$n")
+
+    bar="$(printf "%-${barlength}s" "${ascii_bar:0:rounded_n}")"
+    if [ -n "$tmux" ]; then
+        echo -e "[$(colorize_bg "$bar")]"
+    else
+        echo -e "[$(colorize_fg "$bar")]"
+    fi
+}
+
+format_block() {
+    percent=$BATTERY_PERCENTAGE
+    if   (( $percent > 90 )); then c="█"
+    elif (( $percent > 80 )); then c="▇"
+    elif (( $percent > 68 )); then c="▆"
+    elif (( $percent > 56 )); then c="▅"
+    elif (( $percent > 44 )); then c="▄"
+    elif (( $percent > 32 )); then c="▃"
+    elif (( $percent > 20 )); then c="▂"
+    else                           c="▁"
+    fi
+
+    if [ -n "$tmux" ]; then
+        colorize_bg "$c"
+    else
+        colorize_fg "$c"
+    fi
+}
+
+format_icon() {
+    charged="🔌 "
+    charging="⚡️ "
+    discharging="🔋 "
+
+    if [ -z "$BATTERY_DISCHARGING" -a "$BATTERY_PERCENTAGE" = "100" ]; then
+        echo "$charged"
+    elif [ -z "$BATTERY_DISCHARGING" ]; then
+        echo "$charging"
+    else
+        echo "$discharging"
+    fi
+}
+
+# Print it out
+case "$format" in
+    hearts)
+        echo $(format_hearts) ;;
+    bar)
+        echo $(format_bar) ;;
+    block)
+        echo $(format_block) ;;
+    icon)
+        echo $(format_percent) $(format_icon) ;;
+    *%*)
+        f=$format
+        f="${f//%hearts/$(format_hearts)}"
+        f="${f//%bar/$(format_bar)}"
+        f="${f//%block/$(format_block)}"
+        f="${f//%percent/$(format_percent)}"
+        f="${f//%icon/$(format_icon)}"
+        f="${f//%bg_color/$(bg_color)}"
+        f="${f//%fg_color/$(fg_color)}"
+        f="${f//%reset_color/$RESET_COLOR}"
+        f="${f//%reset/$RESET_COLOR}"
+        echo -e $f
+        ;;
+    *)
+        echo $(format_percent) ;;
+esac


### PR DESCRIPTION
This is general-purpose battery percentage indicator for laptops. There
are quite a few formatters included, and several options.

It is known to work with Ubuntu and Mac OS, and even works on Ubuntu
running through Vagrant/VirtualBox (my use case).

The --tmux option is useful for tmux status bar output. For example, in
my current tmux config, I have the following:

    set -g status-right ' #(hr battery --format="[%%percent]" --charging --color --tmux)'