### PR TITLE
Set the PGDATABASE env var when hcd is used

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -127,4 +127,4 @@ cdpath=(~ ~/src $DEV_DIR $SOURCE_DIR)
 # remove duplicates in $PATH
 typeset -aU path
 
-[[ -s $(brew --prefix)/etc/profile.d/autojump.sh ]] && . $(brew --prefix)/etc/profile.d/autojump.sh
+command -v brew && [[ -s $(brew --prefix)/etc/profile.d/autojump.sh ]] && . $(brew --prefix)/etc/profile.d/autojump.sh

--- a/hr/libexec/hr-init
+++ b/hr/libexec/hr-init
@@ -56,12 +56,17 @@ ${wrapper_function:-hr}() {
     shift
   fi
 
+  export TMPFILE=/tmp/hr-export-source
+
   case "\$command" in
   ${commands[*]})
     eval \`hr "sh-\$command" "\$@"\`;;
   *)
     command hr "\$command" "\$@";;
   esac
+
+  export \`cat \$TMPFILE 2> /dev/null\` > /dev/null
+  rm -f $TMPFILE
 }
 EOS
 

--- a/hr/libexec/hr-sh-cd
+++ b/hr/libexec/hr-sh-cd
@@ -3,6 +3,7 @@
 path="$(command hr-cd "$1")"
 
 if [ -d "$path" ]; then
+  echo PGDATABASE=`basename $path`"_development" > "$TMPFILE"
   echo "cd $path"
 else
   echo "No such directory: $path" >&2


### PR DESCRIPTION
When opening `psql` with the PGDATABASE env var set
the connected database will be the name in the env
var.

This feature relies on the convention of having a database
with the same name as the project but with `_development` as
a suffix.

When hcd is used, the PGDATABASE env var is set and
we acquire the convienience of only ever needing to type
`psql`.