### PR TITLE
In vim tell confused visual bell, "do nothing" see #64, 😎 👌

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -9,6 +9,7 @@ syntax on
 filetype plugin indent on
 
 set visualbell
+set t_vb=
 
 set wildmenu
 set wildmode=list:longest,full


### PR DESCRIPTION
For more information see [issue](https://github.com/hashrocket/dotmatrix/issues/68)

Works great on MacBookPro 2012-2015, 
macOS Sierra operating system.

Happy to make changes or provide additional information.
solution sourced from: [disable audio/visual bells in vim](https://unix.stackexchange.com/questions/5310/how-can-i-disable-bells-visualbells-in-vim)

Cheers, Michael Dimmitt
