### PR TITLE
Add an alias for rebasing feature branches

### DIFF
--- a/.sharedrc
+++ b/.sharedrc
@@ -122,6 +122,7 @@ alias gra='git rebase --abort'
 alias gco='git checkout'
 alias reset-authors='git commit --amend --reset-author -C HEAD'
 alias vi='vim'
+alias grim='git rebase -i master'
 
 if [ "$(uname)" = Darwin -a "$(command -v vim)" = /usr/bin/vim ]; then
   bettervim="/Applications/MacVim.app/Contents/MacOS/Vim"


### PR DESCRIPTION
This is an alias I use often to reword, edit, squash, fixup, and execute on Git commits prior to merging a feature branch or opening a pull request. `master` is a Git reference to where your branch diverges from our standard default branch, `master`. I think adding this to Dotmatrix will encourage users to pare down their Git history to just the essential information.