### PR TITLE
Remove NeoFormat in favor of ALE for formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/.vimbundle
+++ b/.vimbundle
@@ -62,7 +62,6 @@ Plug 'nelstrom/vim-textobj-rubyblock'
 Plug 'exu/pgsql.vim'
 Plug 'elixir-lang/vim-elixir'
 Plug 'mxw/vim-jsx'
-Plug 'sbdchd/neoformat'
 Plug 'hashrocket/vim-hashrocket'
 
 " staticly check code and highlight errors (async syntastic replacement)

--- a/.vimrc
+++ b/.vimrc
@@ -30,6 +30,9 @@ augroup vimrc
   autocmd GuiEnter * set columns=120 lines=70 number
 augroup END
 
+" shows the output from prettier - useful for syntax errors
+nnoremap <leader>pt :!prettier %<CR>
+
 " Plugin Configuration: {{{
 
   " ALE: {{{
@@ -39,33 +42,21 @@ augroup END
     highlight link ALEErrorSign WarningMsg
     nnoremap <silent> <leader>ne :ALENextWrap<CR>
     nnoremap <silent> <leader>pe :ALEPreviousWrap<CR>
+
+    let g:ale_fixers = {
+          \   'javascript': ['prettier'],
+          \   'javascript.jsx': ['prettier'],
+          \   'json': ['prettier'],
+          \   'scss': ['prettier'],
+          \   'ruby': ['rubocop'],
+          \   'bash': ['shfmt'],
+          \   'zsh': ['shfmt'],
+          \   'elixir': ['mix_format'],
+          \}
+
+    let g:ale_fix_on_save = 1
   " }}}
 
-  " NeoFormat: {{{
-    " shows the output from prettier - useful for syntax errors
-    nnoremap <leader>pt :!prettier %<CR>
-
-    " ONLY PRETTIER (don't run any other formatters for these file types)
-    let g:neoformat_enabled_javascript = ['prettier']
-    let g:neoformat_enabled_css = ['prettier']
-    let g:neoformat_enabled_scss = ['prettier']
-    let g:neoformat_enabled_json = ['prettier']
-
-    " default settings for prettier on javascript
-    let g:neoformat_javascript_prettier = {
-      \ 'exe': 'prettier',
-      \ 'args': ['--stdin', '--print-width 80', '--single-quote', '--trailing-comma es5'],
-      \ 'stdin': 1,
-      \ }
-
-    " OPT-IN - to run neoformat when saving certain files copy the following
-    " into your .vimrc.local:
-    "
-    " augroup NeoformatAutoFormat
-    "   autocmd!
-    "   autocmd BufWritePre *.{js,jsx,css,scss,json,ex,exs} Neoformat
-    " augroup END
-  " }}}
 " }}}
 
 if filereadable(expand('~/.vimrc.local'))


### PR DESCRIPTION
Since ALE is capable of autoformatting code and linting there is no need
for NeoFormat.

ALE's autoformatting also allows using lambda functions and allows to
easily disable autoformatting for a buffer which comes in handy when
running `:Btabedit`.

This also removes the forced prettier configuration that was hardcoded into
vimrc. Instead place a .prettierrc in your $HOME folder which you can
override with a .prettierrc file in your project dir.