### PR TITLE
Turn on psql timing

### DIFF
--- a/.psqlrc
+++ b/.psqlrc
@@ -2,3 +2,4 @@
 \pset null 'ø'
 \x auto
 \set QUIET 0
+\timing


### PR DESCRIPTION
I've had this setting turned on for years on every machine I use. It's unobtrusive and can provide interesting and useful information.