### PR TITLE
Prepend turbux commands with "bundle exec"

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -60,6 +60,8 @@ nnoremap <leader>pt :!prettier %<CR>
 
 " }}}
 
+let g:turbux_command_prefix = 'bundle exec'
+
 if filereadable(expand('~/.vimrc.local'))
   source ~/.vimrc.local
 endif


### PR DESCRIPTION
I want to make sure that my tests are using the bundled version of RSpec, and not one available globally through my version manager. In the past, `Leader + t` in a spec would run `rspec spec/feature/your_spec.rb`

**This PR -** 
* Adds `bundle exec` in front of turbux commands. 

Now, it should be the following: `bundle exec rspec spec/feature/your_spec.rb`