### PR TITLE
True colors for tmux

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -2,6 +2,7 @@
 setw -g mode-keys vi
 
 set -g default-terminal "screen-256color"
+set -sa terminal-overrides ',*256*:Tc'
 
 unbind C-b
 set -g prefix C-z


### PR DESCRIPTION
<img width="548" alt="image" src="https://user-images.githubusercontent.com/597909/67147359-fb155080-f259-11e9-98b2-94857ffa2eef.png">

Run this in tmux to see if you have true color support

```
awk 'BEGIN{
    s="/\\/\\/\\/\\/\\"; s=s s s s s s s s;
    for (colnum = 0; colnum<77; colnum++) {
        r = 255-(colnum*255/76);
        g = (colnum*510/76);
        b = (colnum*255/76);
        if (g>255) g = 510-g;
        printf "\033[48;2;%d;%d;%dm", r,g,b;
        printf "\033[38;2;%d;%d;%dm", 255-r,255-g,255-b;
        printf "%s\033[0m", substr(s,colnum+1,1);
    }
    printf "\n";
}'

```