### PR TITLE
Allow psql to use a different history for each DB

### DIFF
--- a/.psqlrc
+++ b/.psqlrc
@@ -3,3 +3,4 @@
 \x auto
 \set QUIET 0
 \timing
+\set HISTFILE ~/.psql_history-:DBNAME


### PR DESCRIPTION
Co-authored-by: Jake Worth <jake.worth@hashrocket.com>
Co-authored-by: Philip Capel <phil.capel@hashrocket.com>

With this setting, psql will create a unique history file for each database it connects to, in the format of `.psql_history-your-database-name`.

This extends the number of commands that can be saved for each database by isolating them, and reduces the chance of running a destructive command in a remote psql session.

More info:

https://til.hashrocket.com/posts/c2cb0fd702-know-your-histfile