### PR TITLE
Updated .sharedrc l func declaration

### DIFF
--- a/.sharedrc
+++ b/.sharedrc
@@ -58,7 +58,7 @@ alias rd='rmdir'
 
 # File management functions
 #
-l.() {
+function l {
   ls -ld "${1:-$PWD}"/.[^.]*
 }
 


### PR DESCRIPTION
On a fresh Fedora 32 system with zsh installed and a fresh install of
dotmatrix the following error is experienced when typing a command at
the prompt:

```
/$HOME/.sharedrc:61: defining function based on alias `ls`
/$HOME/.sharedrc:61: parse error near `()`
zsh: git_prompt_info: command not found...
```

Since `git_prompt_info` is defined in .sharedrc and since it is not able
to be parsed we end up with a few errors, all of which are resolved by
changing the syntax for declaring this function.