### PR TITLE
Add :Driver command to re-source user specific rc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -60,6 +60,20 @@ nnoremap <leader>pt :!prettier %<CR>
 
 " }}}
 
+" Allow different drivers to quickly re-source their personal configurations
+" for ease of navigation and code manipulation
+fu! Driver(name)
+  let fname='~/.vimrc.' . a:name
+  if filereadable(expand(fname))
+    exec "source " . fname
+  else
+    echomsg "Cannot read configuration " . fname . ", please ensure that you have your developer config present on this machine."
+  endif
+endfu
+
+:command! -nargs=1 Driver :call Driver(<q-args>)
+
+" this may no longer be required.
 if filereadable(expand('~/.vimrc.local'))
   source ~/.vimrc.local
 endif


### PR DESCRIPTION
### What
A convenience function that allows you to quickly source a configuration file scoped to your own handle (e.g. `.vimrc.pcapel`).

### Why
Sometimes working using another developer's configuration options can be frustrating, particularly when they affect the native defaults. This is a pain point for both developers, and this could act as a convenient compromise.